### PR TITLE
Add td_upload_embulk

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Maintainer: Aki Ariga <chezou@gmail.com>
 Description: 
   Execute TD Toolbelt, see <https://toolbelt.treasuredata.com>. 
   You can execute database or table handling and upload data.frame to Arm Treasure Data.
-SystemRequirements: TD toolbelt
+SystemRequirements: TD toolbelt, embulk
 License: Apache License 2.0 | file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/R/td.R
+++ b/R/td.R
@@ -40,6 +40,65 @@ td_upload <- function(dbname, table, df, overwrite = FALSE) {
   import_auto(paste(dbname, table, sep = '.'), tmpfname, format = 'tsv', column_types = column_types)
 }
 
+#' Upload data.frame to TD
+#'
+#' @param dbname Target destination database name.
+#' @param table Target table name.
+#' @param df Input data.frame.
+#' @param embulk_dir Path to embulk. [optional]
+#' @param overwrite Flag for overwriting the table if exists. It doesn't overwrite database.
+#'
+#' @examples
+#' \dontrun{
+#' td_upload_embulk("mydb", "iris", iris)
+#'
+#' # With overwrite option
+#' td_upload_embulk("mydb", "iris", iris, overwrite = TRUE)
+#'
+#' # With overwrite option
+#' td_upload_embulk("mydb", "iris", iris, "/path/to/embulk", overwrite = TRUE)
+#' }
+#'
+#' @importFrom readr write_tsv
+#' @export
+td_upload_embulk <- function(dbname, table, df, embulk_dir, overwrite = FALSE) {
+  embulk_exec <- ifelse(missing(embulk_dir), "embulk", file.path(embulk_dir, "embulk"))
+  if(.Platform$OS.type == "windows") {
+    embulk_exec <- paste0(embulk_exec, ".bat")
+  }
+
+  if(Sys.which(embulk_exec) == ''){
+    stop("embulk isn't found. Ensure PATH is set for embulk or use embulk_dir option.")
+  }
+
+  exists_db <- db_exists(dbname)
+  exists_table <- table_exists(dbname, table)
+  if(!overwrite && exists_table) {
+    stop(paste0('"', dbname, ".", table, '" is already exists.'))
+  }
+  if(!exists_db) {
+    db_create(dbname)
+  }
+  if(overwrite && exists_table) {
+    table_delete(dbname, table)
+  }
+  table_create(dbname, table)
+
+  template_path <- system.file("extdata", "tsv_upload.yml.liquid", package="RTD")
+  temp_dir <- tempdir()
+  temp_tsv <- tempfile(fileext = ".tsv", pattern = "embulk_", tmpdir = temp_dir)
+
+  # Replace NA as an empty string
+  readr::write_tsv(df, temp_tsv, na= "")
+  load_yml <- file.path(temp_dir, "load.yml")
+
+  # Set environment variable for embulk
+  Sys.setenv(dbname=dbname, table=table, path_prefix=temp_tsv)
+
+  system2(embulk_exec, paste("guess", template_path, "-o", load_yml))
+  system2(embulk_exec, paste("run", load_yml))
+}
+
 .guess_column_types <- function(df) {
   guessed_types <- sapply(df, function(x){
     if(is.factor(x) || is.character(x)) {

--- a/inst/extdata/tsv_upload.yml.liquid
+++ b/inst/extdata/tsv_upload.yml.liquid
@@ -1,0 +1,11 @@
+in:
+    type: file
+    path_prefix: {{ env.path_prefix }}
+out:
+    type: td
+    apikey: {{ env.TD_API_KEY }}
+    endpoint: {% if env.TD_API_SERVER %}{{ env.TD_API_SERVER }}{% else %} api.treasuredata.com{% endif %}
+    database: {{ env.dbname }}
+    table: {{ env.table }}
+    mode: replace
+    default_timestamp_format: '%Y-%m-%d %H:%M:%S'

--- a/tests/testthat/test-td.R
+++ b/tests/testthat/test-td.R
@@ -20,3 +20,28 @@ test_that("td_upload works with mock",{
   )
   expect_args(m, TRUE, "td", "import:auto --format tsv --auto-create test.iris --column-header --column-types double,double,double,double,string --time-value 1544713200 /tmp/filed7ff398c8e.tsv")
 })
+
+
+
+test_that("td_upload_embulk works with mock",{
+  test_time <- as.POSIXlt("2018-12-13 15:00:00", tz="GMT")
+  template_path <- system.file("extdata", "tsv_upload.yml.liquid", package="RTD")
+  m <- mock(0, 0)
+  with_mock(
+    db_exists = mock(FALSE),
+    table_exists = mock(FALSE),
+    db_create = mock(TRUE),
+    table_create = mock(TRUE),
+    table_delete = mock(TRUE),
+    tempdir = mock("/tmp"),
+    `system.file` = mock("/home/R/package/RTD/extdata/tsv_upload.yml.liquid"),
+    `Sys.which` = mock("/home/RTD/bin/embulk"),
+    `Sys.time` = mock(test_time),
+    `system2` = m,
+    {
+      td_upload_embulk("test", "iris", iris)
+    }
+  )
+  expect_args(m, 1, "embulk", paste("guess", template_path, "-o /tmp/load.yml"))
+  expect_args(m, 2, "embulk", "run /tmp/load.yml")
+})

--- a/tests/testthat/test-td.R
+++ b/tests/testthat/test-td.R
@@ -34,7 +34,7 @@ test_that("td_upload_embulk works with mock",{
     table_create = mock(TRUE),
     table_delete = mock(TRUE),
     tempdir = mock("/tmp"),
-    `system.file` = mock("/home/R/package/RTD/extdata/tsv_upload.yml.liquid"),
+    #`system.file` = mock("/home/R/package/RTD/extdata/tsv_upload.yml.liquid"),
     `Sys.which` = mock("/home/RTD/bin/embulk"),
     `Sys.time` = mock(test_time),
     `system2` = m,


### PR DESCRIPTION
This PR introduces `td_upload_embulk` function which uploads data.frame via embulk. It is recommended bulk import way of TD.

After this PR, I will replace TD toolbelt dependencies into REST API.