### PR TITLE
Fix deprecated testthat::with_mock() warnings

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^RTD.Rcheck$
 ^.java-version$
 ^.github$
+^SECURITY\.md$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,6 @@
 ^.java-version$
 ^.github$
 ^SECURITY\.md$
+^\.git$
+^\.gitignore$
+^.*\.Rcheck$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,7 @@
 Package: RTD
 Title: Simple TD API Client
 Version: 0.4.1.900
+Author: Aki Ariga <ariga@treasure-data.com>
 Authors@R: 
     person(given = "Aki",
            family = "Ariga",
@@ -13,7 +14,6 @@ Description:
 SystemRequirements: embulk, embulk-output-td
 License: Apache License 2.0 | file LICENSE
 Encoding: UTF-8
-LazyData: true
 URL: https://github.com/treasure-data/RTD
 BugReports: https://github.com/treasure-data/RTD/issues
 RoxygenNote: 7.1.1

--- a/tests/testthat/test-td.R
+++ b/tests/testthat/test-td.R
@@ -5,6 +5,34 @@ library(mockery)
 con <- Td(apikey = "xxxxx")
 embulk_exec <- if (.Platform$OS.type == "windows") "embulk.bat" else "embulk"
 
+# Setup fake embulk once for all tests
+setup_fake_embulk <- function() {
+  # Create a temporary directory with a fake embulk
+  fake_embulk_dir <- tempfile()
+  dir.create(fake_embulk_dir, recursive = TRUE)
+
+  # Create platform-specific fake embulk
+  if (.Platform$OS.type == "windows") {
+    fake_embulk <- file.path(fake_embulk_dir, "embulk.bat")
+    writeLines("@echo off\necho fake embulk", fake_embulk)
+  } else {
+    fake_embulk <- file.path(fake_embulk_dir, "embulk")
+    writeLines("#!/bin/bash\necho 'fake embulk'", fake_embulk)
+    Sys.chmod(fake_embulk, mode = "0755")
+  }
+
+  # Temporarily modify PATH
+  old_path <- Sys.getenv("PATH")
+  path_sep <- if (.Platform$OS.type == "windows") ";" else ":"
+  Sys.setenv(PATH = paste(fake_embulk_dir, old_path, sep = path_sep))
+
+  # Return cleanup function
+  function() {
+    Sys.setenv(PATH = old_path)
+    unlink(fake_embulk_dir, recursive = TRUE)
+  }
+}
+
 # TODO: test for "bulk_import" mode
 test_that("td_upload works with mock", {
   template_path <- system.file("extdata", "tsv_upload.yml.liquid", package = "RTD")
@@ -20,8 +48,10 @@ test_that("td_upload works with mock", {
     .package = "RTD"
   )
 
+  # Mock tempdir to return platform-appropriate path
+  temp_base <- if (.Platform$OS.type == "windows") "C:/tmp" else "/tmp"
   local_mocked_bindings(
-    tempdir = function(...) "/tmp",
+    tempdir = function(...) temp_base,
     system2 = m,
     .package = "base"
   )
@@ -31,35 +61,13 @@ test_that("td_upload works with mock", {
     .package = "readr"
   )
 
-  # Mock Sys.which separately by setting a fake embulk in PATH
-  local({
-    # Create a temporary directory with a fake embulk
-    fake_embulk_dir <- tempfile()
-    dir.create(fake_embulk_dir)
+  # Setup fake embulk and ensure cleanup
+  cleanup_embulk <- setup_fake_embulk()
+  on.exit(cleanup_embulk())
 
-    # Create platform-specific fake embulk
-    if (.Platform$OS.type == "windows") {
-      fake_embulk <- file.path(fake_embulk_dir, "embulk.bat")
-      writeLines("@echo off\necho fake embulk", fake_embulk)
-    } else {
-      fake_embulk <- file.path(fake_embulk_dir, "embulk")
-      writeLines("#!/bin/bash\necho 'fake embulk'", fake_embulk)
-      Sys.chmod(fake_embulk, mode = "0755")
-    }
-
-    # Temporarily modify PATH
-    old_path <- Sys.getenv("PATH")
-    path_sep <- if (.Platform$OS.type == "windows") ";" else ":"
-    Sys.setenv(PATH = paste(fake_embulk_dir, old_path, sep = path_sep))
-    on.exit({
-      Sys.setenv(PATH = old_path)
-      unlink(fake_embulk_dir, recursive = TRUE)
-    })
-
-    td_upload(con, "test", "iris", iris, mode = "embulk")
-    expect_args(m, 1, embulk_exec, paste("guess", template_path, "-o /tmp/load.yml"))
-    expect_args(m, 2, embulk_exec, "run /tmp/load.yml")
-  })
+  td_upload(con, "test", "iris", iris, mode = "embulk")
+  expect_args(m, 1, embulk_exec, paste("guess", template_path, paste0("-o ", temp_base, "/load.yml")))
+  expect_args(m, 2, embulk_exec, paste0("run ", temp_base, "/load.yml"))
 })
 
 test_that("td_upload works with mock when the table already exists", {
@@ -76,8 +84,10 @@ test_that("td_upload works with mock when the table already exists", {
     .package = "RTD"
   )
 
+  # Mock tempdir to return platform-appropriate path
+  temp_base <- if (.Platform$OS.type == "windows") "C:/tmp" else "/tmp"
   local_mocked_bindings(
-    tempdir = function(...) "/tmp",
+    tempdir = function(...) temp_base,
     system2 = m,
     .package = "base"
   )
@@ -87,34 +97,12 @@ test_that("td_upload works with mock when the table already exists", {
     .package = "readr"
   )
 
-  # Mock Sys.which separately by setting a fake embulk in PATH
-  local({
-    # Create a temporary directory with a fake embulk
-    fake_embulk_dir <- tempfile()
-    dir.create(fake_embulk_dir)
+  # Setup fake embulk and ensure cleanup
+  cleanup_embulk <- setup_fake_embulk()
+  on.exit(cleanup_embulk())
 
-    # Create platform-specific fake embulk
-    if (.Platform$OS.type == "windows") {
-      fake_embulk <- file.path(fake_embulk_dir, "embulk.bat")
-      writeLines("@echo off\necho fake embulk", fake_embulk)
-    } else {
-      fake_embulk <- file.path(fake_embulk_dir, "embulk")
-      writeLines("#!/bin/bash\necho 'fake embulk'", fake_embulk)
-      Sys.chmod(fake_embulk, mode = "0755")
-    }
-
-    # Temporarily modify PATH
-    old_path <- Sys.getenv("PATH")
-    path_sep <- if (.Platform$OS.type == "windows") ";" else ":"
-    Sys.setenv(PATH = paste(fake_embulk_dir, old_path, sep = path_sep))
-    on.exit({
-      Sys.setenv(PATH = old_path)
-      unlink(fake_embulk_dir, recursive = TRUE)
-    })
-
-    expect_error(td_upload(con, "test", "iris", iris), ".* already exists.")
-    td_upload(con, "test", "iris", iris, mode = "embulk", overwrite = TRUE)
-    expect_args(m, 1, embulk_exec, paste("guess", template_path, "-o /tmp/load.yml"))
-    expect_args(m, 2, embulk_exec, "run /tmp/load.yml")
-  })
+  expect_error(td_upload(con, "test", "iris", iris), ".* already exists.")
+  td_upload(con, "test", "iris", iris, mode = "embulk", overwrite = TRUE)
+  expect_args(m, 1, embulk_exec, paste("guess", template_path, paste0("-o ", temp_base, "/load.yml")))
+  expect_args(m, 2, embulk_exec, paste0("run ", temp_base, "/load.yml"))
 })

--- a/tests/testthat/test-td.R
+++ b/tests/testthat/test-td.R
@@ -9,40 +9,112 @@ embulk_exec <- if (.Platform$OS.type == "windows") "embulk.bat" else "embulk"
 test_that("td_upload works with mock", {
   template_path <- system.file("extdata", "tsv_upload.yml.liquid", package = "RTD")
   m <- mock(0, 0)
-  with_mock(
-    exist_database = mock(FALSE),
-    exist_table = mock(FALSE),
-    create_database = mock(TRUE),
-    create_table = mock(TRUE),
-    delete_table = mock(TRUE),
-    tempdir = mock("/tmp"),
-    `readr::write_tsv` = mock(TRUE),
-    `Sys.which` = mock("/home/RTD/bin/embulk"),
-    `system2` = m, {
-      td_upload(con, "test", "iris", iris, mode = "embulk")
-    }
+
+  # Use local_mocked_bindings for functions that exist
+  local_mocked_bindings(
+    exist_database = function(...) FALSE,
+    exist_table = function(...) FALSE,
+    create_database = function(...) TRUE,
+    create_table = function(...) TRUE,
+    delete_table = function(...) TRUE,
+    .package = "RTD"
   )
-  expect_args(m, 1, embulk_exec, paste("guess", template_path, "-o /tmp/load.yml"))
-  expect_args(m, 2, embulk_exec, "run /tmp/load.yml")
+
+  local_mocked_bindings(
+    tempdir = function(...) "/tmp",
+    system2 = m,
+    .package = "base"
+  )
+
+  local_mocked_bindings(
+    write_tsv = function(...) TRUE,
+    .package = "readr"
+  )
+
+  # Mock Sys.which separately by setting a fake embulk in PATH
+  local({
+    # Create a temporary directory with a fake embulk
+    fake_embulk_dir <- tempfile()
+    dir.create(fake_embulk_dir)
+
+    # Create platform-specific fake embulk
+    if (.Platform$OS.type == "windows") {
+      fake_embulk <- file.path(fake_embulk_dir, "embulk.bat")
+      writeLines("@echo off\necho fake embulk", fake_embulk)
+    } else {
+      fake_embulk <- file.path(fake_embulk_dir, "embulk")
+      writeLines("#!/bin/bash\necho 'fake embulk'", fake_embulk)
+      Sys.chmod(fake_embulk, mode = "0755")
+    }
+
+    # Temporarily modify PATH
+    old_path <- Sys.getenv("PATH")
+    path_sep <- if (.Platform$OS.type == "windows") ";" else ":"
+    Sys.setenv(PATH = paste(fake_embulk_dir, old_path, sep = path_sep))
+    on.exit({
+      Sys.setenv(PATH = old_path)
+      unlink(fake_embulk_dir, recursive = TRUE)
+    })
+
+    td_upload(con, "test", "iris", iris, mode = "embulk")
+    expect_args(m, 1, embulk_exec, paste("guess", template_path, "-o /tmp/load.yml"))
+    expect_args(m, 2, embulk_exec, "run /tmp/load.yml")
+  })
 })
 
 test_that("td_upload works with mock when the table already exists", {
   template_path <- system.file("extdata", "tsv_upload.yml.liquid", package = "RTD")
   m <- mock(0, 0)
-  with_mock(
-    exist_database = mock(FALSE, cycle = TRUE),
-    exist_table = mock(TRUE, cycle = TRUE),
-    create_database = mock(TRUE, cycle = TRUE),
-    create_table = mock(TRUE, cycle = TRUE),
-    delete_table = mock(TRUE, cycle = TRUE),
-    tempdir = mock("/tmp", cycle = TRUE),
-    `readr::write_tsv` = mock(TRUE, cycle = TRUE),
-    `Sys.which` = mock("/home/RTD/bin/embulk", cycle = TRUE),
-    `system2` = m, {
-      expect_error(td_upload(con, "test", "iris", iris), ".* already exists.")
-      td_upload(con, "test", "iris", iris, mode = "embulk", overwrite = TRUE)
-    }
+
+  # Use local_mocked_bindings for functions that exist
+  local_mocked_bindings(
+    exist_database = function(...) FALSE,
+    exist_table = function(...) TRUE,
+    create_database = function(...) TRUE,
+    create_table = function(...) TRUE,
+    delete_table = function(...) TRUE,
+    .package = "RTD"
   )
-  expect_args(m, 1, embulk_exec, paste("guess", template_path, "-o /tmp/load.yml"))
-  expect_args(m, 2, embulk_exec, "run /tmp/load.yml")
+
+  local_mocked_bindings(
+    tempdir = function(...) "/tmp",
+    system2 = m,
+    .package = "base"
+  )
+
+  local_mocked_bindings(
+    write_tsv = function(...) TRUE,
+    .package = "readr"
+  )
+
+  # Mock Sys.which separately by setting a fake embulk in PATH
+  local({
+    # Create a temporary directory with a fake embulk
+    fake_embulk_dir <- tempfile()
+    dir.create(fake_embulk_dir)
+
+    # Create platform-specific fake embulk
+    if (.Platform$OS.type == "windows") {
+      fake_embulk <- file.path(fake_embulk_dir, "embulk.bat")
+      writeLines("@echo off\necho fake embulk", fake_embulk)
+    } else {
+      fake_embulk <- file.path(fake_embulk_dir, "embulk")
+      writeLines("#!/bin/bash\necho 'fake embulk'", fake_embulk)
+      Sys.chmod(fake_embulk, mode = "0755")
+    }
+
+    # Temporarily modify PATH
+    old_path <- Sys.getenv("PATH")
+    path_sep <- if (.Platform$OS.type == "windows") ";" else ":"
+    Sys.setenv(PATH = paste(fake_embulk_dir, old_path, sep = path_sep))
+    on.exit({
+      Sys.setenv(PATH = old_path)
+      unlink(fake_embulk_dir, recursive = TRUE)
+    })
+
+    expect_error(td_upload(con, "test", "iris", iris), ".* already exists.")
+    td_upload(con, "test", "iris", iris, mode = "embulk", overwrite = TRUE)
+    expect_args(m, 1, embulk_exec, paste("guess", template_path, "-o /tmp/load.yml"))
+    expect_args(m, 2, embulk_exec, "run /tmp/load.yml")
+  })
 })


### PR DESCRIPTION
This PR migrates from deprecated testthat::with_mock() to the mockery package to resolve deprecation warnings.

Closes #22, #23